### PR TITLE
Fix drinking and consuming animation (HeldItemRendererMixin.java)

### DIFF
--- a/src/main/java/io/github/takfsg/oldblockhit/mixin/HeldItemRendererMixin.java
+++ b/src/main/java/io/github/takfsg/oldblockhit/mixin/HeldItemRendererMixin.java
@@ -67,19 +67,23 @@ public class HeldItemRendererMixin {
     @Overwrite
     private void method_9867(AbstractClientPlayerEntity abstractClientPlayerEntity, float f) {
         if (Config.oldConsume) {
-            float useAmount = (float) abstractClientPlayerEntity.getItemUseTicks() - f + 1.0F;
-            float f1 = 1.0F - useAmount / (float) field_1877.getMaxUseTime();
-            float f2 = 1.0F - f1;
-            f2 = f2 * f2 * f2;
-            f2 = f2 * f2 * f2;
-            f2 = f2 * f2 * f2;
-            float f3 = 1.0F - f2;
-            GlStateManager.translatef(0.0F, MathHelper.abs(MathHelper.cos(useAmount / 4.0F * 3.1415927F) * 0.1F) * (float) ((double) f1 > 0.2D ? 1 : 0), 0.0F);
-            GlStateManager.translatef(f3 * 0.6F, -f3 * 0.5F, 0.0F);
-            GlStateManager.rotatef(f3 * 90.0F, 0.0F, 1.0F, 0.0F);
-            GlStateManager.rotatef(f3 * 10.0F, 1.0F, 0.0F, 0.0F);
-            GlStateManager.rotatef(f3 * 30.0F, 0.0F, 0.0F, 1.0F);
-        } else {
+	           float useAmount = (float) abstractClientPlayerEntity.getItemUseTicks() - f + 1.0F;
+	           float f1 = 1.0F - useAmount / (float) field_1877.getMaxUseTime();
+	           float f2 = 1.0F - f1;
+	           f2 = f2 * f2 * f2;
+	           f2 = f2 * f2 * f2;
+	           f2 = f2 * f2 * f2;
+	           f2 -= 0.05F;
+	           float j = 1.0F - f2;
+	           GlStateManager.translatef(0.0F, MathHelper.abs(MathHelper.cos(useAmount / 4F * (float) Math.PI) * 0.11F)
+	    		         * (f1 > 0.2D ? 1 : 0), 0.0F);
+	           GlStateManager.translatef(j * 0.6F, -j * 0.5F, 0.0F);
+	           GlStateManager.rotatef(j * 90.0F, 0.0F, 1.0F, 0.0F);
+	           GlStateManager.rotatef(j * 10.0F, 1.0F, 0.0F, 0.0F);
+	           GlStateManager.rotatef(j * 30.0F, 0.0F, 0.0F, 1.0F);
+	           GlStateManager.translatef(0, -0.0F, 0.06F);
+	           GlStateManager.rotatef(-4F, 1, 0, 0);
+ 	    } else {
             float g = (float)abstractClientPlayerEntity.getItemUseTicks() - f + 1.0F;
             float h = g / (float)this.field_1877.getMaxUseTime();
             float i = MathHelper.abs(MathHelper.cos(g / 4.0F * 3.1415927F) * 0.1F);


### PR DESCRIPTION
The eating and drinking animations looked almost like the original 1.8 ones, so I replaced them with ones from Sol Client.

old ones

![image](https://github.com/TAKfsg/oldblockhit-legacy-fabric/assets/85581164/b6cf86ed-9518-4cd8-b642-1139282c5284)

new ones

![image](https://github.com/TAKfsg/oldblockhit-legacy-fabric/assets/85581164/d482c5fb-b5e6-4331-bb4c-56d3eda4fc62)
